### PR TITLE
Add new table that shows Jira issues you logged time to that day

### DIFF
--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -55,6 +55,7 @@ def print_page(df, dates, data):
     print_daily_totals(df, dates)
     print_issue_list(df, dates)
     add_hours_form(data, dates)
+    print_issues_worked_on_today(df)
 
 def print_issue_list(df, dates):
     # Create an empty DataFrame with the required columns
@@ -111,5 +112,11 @@ def add_hours_form(data, dates):
         issue_key = selected_issue.split(" - ")[0]
         st.success(f"Logged {hours} hours for {issue_key} on {selected_date}")
         jira_functions.add_time(issue_key, f"{hours}h")
+
+def print_issues_worked_on_today(df):
+    st.subheader("Issues worked on this week")
+    today = datetime.now().strftime('%Y-%m-%d')
+    issues_today = df[df[today] > 0]
+    st.dataframe(issues_today, hide_index=True)
 
 main()


### PR DESCRIPTION
Add a new table to show issues worked on today

* Add a new heading "Issues worked on this week" in `src/streamlit_app.py`
* Add a new function `print_issues_worked_on_today` to display issues with worklogs started today
* Filter issues to show only those with worklogs started on the current day
* Display the time logged for each issue specifically for the current day

